### PR TITLE
Changes to MCC Connection and Table classes

### DIFF
--- a/src/main/java/org/apache/hadoop/hbase/client/HBaseMultiClusterConfigUtil.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/HBaseMultiClusterConfigUtil.java
@@ -25,7 +25,6 @@ import java.util.zip.*;
 import com.cloudera.api.ClouderaManagerClientBuilder;
 import com.cloudera.api.DataView;
 import com.cloudera.api.model.*;
-import com.cloudera.api.v1.*;
 import com.cloudera.api.v8.RootResourceV8;
 import com.cloudera.api.v8.ServicesResourceV8;
 import org.apache.cxf.jaxrs.ext.multipart.InputStreamDataSource;

--- a/src/main/java/org/apache/hadoop/hbase/client/HConnectionManagerMultiClusterWrapper.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/HConnectionManagerMultiClusterWrapper.java
@@ -37,10 +37,9 @@ public class HConnectionManagerMultiClusterWrapper {
             .getStringCollection(ConfigConst.HBASE_FAILOVER_CLUSTERS_CONFIG);
 
     if (failoverClusters.size() == 0) {
-      LOG.info(" -- Getting a signle cluster connection !!");
+      LOG.info(" -- Getting a single cluster connection !!");
       return HConnectionManager.createConnection(conf);
-    } else {
-
+    } else { 
       Map<String, Configuration> configMap = HBaseMultiClusterConfigUtil
           .splitMultiConfigFile(conf);
 

--- a/src/main/java/org/apache/hadoop/hbase/client/HConnectionMultiCluster.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/HConnectionMultiCluster.java
@@ -110,6 +110,7 @@ public class HConnectionMultiCluster implements HConnection {
     Exception lastException = null;
     try {
       primaryConnection.close();
+      LOG.info("Closed primary connection");
     } catch (Exception e) {
       LOG.error("Exception while closing primary", e);
       lastException = e;
@@ -117,10 +118,20 @@ public class HConnectionMultiCluster implements HConnection {
     for (HConnection failOverConnection : failoverConnections) {
       try {
         failOverConnection.close();
+        LOG.info("Closed failover connection");
       } catch (Exception e) {
         LOG.error("Exception while closing primary", e);
         lastException = e;
       }
+    }
+    if (executor != null) {
+    	try {
+    	  executor.shutdownNow();
+          LOG.info("MCC shutdown successful");
+    	} catch (Exception e) {
+    	  LOG.error("Exception while shutting down MCC executor", e);
+    	  lastException = e;
+    	}
     }
     if (lastException != null) {
       throw new IOException(lastException);
@@ -158,7 +169,6 @@ public class HConnectionMultiCluster implements HConnection {
       failoverHTables.add(htable);
       LOG.info(" --- got failoverHTable");
     }
-
     return new HTableMultiCluster(originalConfiguration, primaryHTable,
         failoverHTables, isMasterMaster, 
         waitTimeBeforeAcceptingResults,

--- a/src/main/java/org/apache/hadoop/hbase/client/HTableStats.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/HTableStats.java
@@ -18,14 +18,11 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.log4j.Logger;
 
 import java.io.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class HTableStats {

--- a/src/main/java/org/apache/hadoop/hbase/client/SpeculativeMutater.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/SpeculativeMutater.java
@@ -33,9 +33,9 @@ import org.apache.commons.logging.LogFactory;
 public class SpeculativeMutater {
   static final Log LOG = LogFactory.getLog(SpeculativeMutater.class);
 
-  static ExecutorService exe = Executors.newFixedThreadPool(200);
+  ExecutorService exe = Executors.newFixedThreadPool(200);
   
-  public static Boolean mutate(final long waitToSendFailover, 
+  public Boolean mutate(final long waitToSendFailover, 
       final long waitToSendFailoverWithException, 
       final HBaseTableFunction<Void> function, 
       final HTableInterface primaryTable,
@@ -102,7 +102,6 @@ public class SpeculativeMutater {
         exeS.submit(call);
       }
       Boolean result = exeS.take().get();
-
       return result;
     } catch (InterruptedException e) {
       e.printStackTrace();
@@ -112,5 +111,9 @@ public class SpeculativeMutater {
       LOG.error(e);
     }    
     return null;
+  }
+  
+  public void shutDown(){
+	  exe.shutdown();
   }
 }

--- a/src/main/java/org/apache/hadoop/hbase/client/SpeculativeRequester.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/SpeculativeRequester.java
@@ -39,7 +39,7 @@ public class SpeculativeRequester<T extends Object> {
   
   static final Log LOG = LogFactory.getLog(SpeculativeRequester.class);
 
-  static ExecutorService exe = Executors.newFixedThreadPool(200);
+  ExecutorService exe = Executors.newFixedThreadPool(200);
   
   public SpeculativeRequester(long waitTimeBeforeRequestingFailover,
       long waitTimeBeforeAcceptingResults,
@@ -134,6 +134,10 @@ public class SpeculativeRequester<T extends Object> {
     
   }
   
+  public void shutDown() {
+	  exe.shutdown();
+  }
+  
   public static class ResultWrapper<T> {
     public Boolean isPrimary;
     public T t;
@@ -144,5 +148,4 @@ public class SpeculativeRequester<T extends Object> {
     }
   }
   
- 
 }

--- a/src/main/java/org/apache/hadoop/hbase/test/MultiThreadedMultiClusterWithCmApiTest.java
+++ b/src/main/java/org/apache/hadoop/hbase/test/MultiThreadedMultiClusterWithCmApiTest.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hbase.test;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;


### PR DESCRIPTION
Changes include
- Ability to create MCC table objects for multiple tables in a client.
- Shutdown `ExecutorService` when MCC Connection object is closed.
- Minor clean-up like removing unused package imports. 
