### PR TITLE
hbase.mcc should be able to connect to a secured (Kerberized) HBase cluster

### DIFF
--- a/src/main/java/org/apache/hadoop/hbase/client/HConnectionManagerMultiClusterWrapper.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/HConnectionManagerMultiClusterWrapper.java
@@ -41,6 +41,17 @@ public class HConnectionManagerMultiClusterWrapper {
       LOG.info(" -- Getting a single cluster connection !!");
       if ("kerberos".equalsIgnoreCase(conf.get("hbase.security.authentication"))) {
         conf.set("hadoop.security.authentication", "Kerberos");
+        String krbPrincipal = conf.get("hbase.mcc.kerberos.principal");
+        String krbKeyTab = conf.get("hbase.mcc.kerberos.keytab");
+        if (krbPrincipal != null && krbKeyTab != null) {
+          try {
+            UserGroupInformation ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(krbPrincipal,krbKeyTab);
+            UserGroupInformation.setLoginUser(ugi);
+          } catch (IOException e) {
+            LOG.error("Not able to login using the principal and keytab provided.");
+            throw e;
+          }
+        }
         UserGroupInformation.setConfiguration(conf);
       }
       return HConnectionManager.createConnection(conf);
@@ -50,6 +61,17 @@ public class HConnectionManagerMultiClusterWrapper {
       Configuration priConfig = configMap.get(HBaseMultiClusterConfigUtil.PRIMARY_NAME);
       if ("kerberos".equalsIgnoreCase(conf.get("hbase.security.authentication"))) {
         conf.set("hadoop.security.authentication", "Kerberos");
+        String krbPrincipal = priConfig.get("hbase.mcc.kerberos.principal");
+        String krbKeyTab = priConfig.get("hbase.mcc.kerberos.keytab");
+        if (krbPrincipal != null && krbKeyTab != null) {
+          try {
+            UserGroupInformation ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(krbPrincipal,krbKeyTab);
+            UserGroupInformation.setLoginUser(ugi);
+          } catch (IOException e) {
+            LOG.error("Not able to login to primary cluster using the principal and keytab provided.");
+            throw e;
+          }
+        }
         UserGroupInformation.setConfiguration(priConfig);
       }
 
@@ -64,6 +86,17 @@ public class HConnectionManagerMultiClusterWrapper {
           Configuration secConfig = entry.getValue();
           if ("kerberos".equalsIgnoreCase(conf.get("hbase.security.authentication"))) {
             conf.set("hadoop.security.authentication", "Kerberos");
+            String krbPrincipal = secConfig.get("hbase.mcc.kerberos.principal");
+            String krbKeyTab = secConfig.get("hbase.mcc.kerberos.keytab");
+            if (krbPrincipal != null && krbKeyTab != null) {
+              try {
+                  UserGroupInformation ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(krbPrincipal,krbKeyTab);
+                  UserGroupInformation.setLoginUser(ugi);
+              } catch (IOException e) {
+                  LOG.error("Not able to login to failover cluster using the principal and keytab provided.");
+                  throw e;
+              }
+            }
             UserGroupInformation.setConfiguration(secConfig);
           }
           failoverConnections.add(HConnectionManager.createConnection(secConfig));


### PR DESCRIPTION
Changes in this PR will help users to use `hbase.mcc` library to connect to Kerberized HBase clusters. The changes will enable use of Kerberos keytab/principal to connect to secure clusters or run the client applications using an user id which has a valid Kerberos ticket from the realm recognized by the secure cluster. 
